### PR TITLE
fix: first/last chapters must be numbers

### DIFF
--- a/site/src/_public/example.html
+++ b/site/src/_public/example.html
@@ -82,7 +82,7 @@ async function update_content(){
         select_translation.value,
         select_book.value,
     )
-    div_content.innerHTML = book.get_chapter(select_chapter.value)
+    div_content.innerHTML = book.get_chapter(Number(select_chapter.value))
 }
 
 


### PR DESCRIPTION
In client/example, an error is thrown because the example passes a string value to the client.

Before:
<img width="1512" alt="image" src="https://github.com/gracious-tech/fetch/assets/2646053/91a8db29-4eed-420f-a101-17c6cea0d651">

This PR converts the value of `select_chapter.value` to a `Number`, which fixes the error.

After:
<img width="1512" alt="image" src="https://github.com/gracious-tech/fetch/assets/2646053/63c040e8-ac73-4787-98a5-20e9b79a5e0c">
